### PR TITLE
Auto convert camel case style to kebab

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 <p align="center">
-  <img src="/public/hat2.png" width="120" /><h1  align="center"><code margin="0"><a href="https://mdxjs.com/">solid-mdx</a></code></h1><p align="center"><i>Easily use <a href="https://github.com/tannerlinsley/react-query">Markdown</a> files for content and documentation in your  <code><a href="https://solidjs.com">solid-js</a></code> apps
+  <h1 align="center"><code margin="0"><a href="https://mdxjs.com/">solid-mdx</a></code></h1><p align="center"><i>Easily use <a href="https://github.com/tannerlinsley/react-query">Markdown</a> files for content and documentation in your  <code><a href="https://solidjs.com">solid-js</a></code> apps
 </p>

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,11 +11,29 @@ import {
 } from "solid-js";
 import { Dynamic } from "solid-js/web";
 
+function convertCamelToKebab(obj: Record<string, string>): Record<string, string> {
+  const kebabObj: Record<string, string> = {};
+
+  for (let key in obj) {
+    if (obj.hasOwnProperty(key)) {
+      const kebabKey = key.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase();
+      kebabObj[kebabKey] = obj[key];
+    }
+  }
+
+  return kebabObj;
+}
+
 export const MDXContext = createContext(
   Object.fromEntries(
     [...HTMLElements, ...SVGElements.keys()].map((el) => [
       el,
-      function (props: any) {
+      function(props: any) {
+        // Transform style
+        if (props.style) {
+          props.style = convertCamelToKebab(props.style)
+        }
+
         props = mergeProps(props, {
           component: el,
         });


### PR DESCRIPTION
MDX will generate code like this:

```
<_components.XXX style={{ marginLeft: "123px" }}>...</_components.span>
```

Without any action, this will result in this:

![invalid-style](https://github.com/nksaraf/solid-mdx/assets/53819558/d34ab10c-ae5b-4816-a1bd-f235864f60f8)
 
This PR fixes the bug by auto converting camel case style to kebab case. 